### PR TITLE
Genesis contract hardening: security fixes for the next genesis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 project/
 target/
+
+# Local-only contract security findings — MUST NOT be pushed to this PUBLIC repo
+# (it maps unpatched live-beta vulnerabilities). Share privately with reviewers.
+SECURITY_FINDINGS_GENESIS.md

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ target/
 # Local-only contract security findings — MUST NOT be pushed to this PUBLIC repo
 # (it maps unpatched live-beta vulnerabilities). Share privately with reviewers.
 SECURITY_FINDINGS_GENESIS.md
+
+# private genesis handoff (never push to the public repo)
+GENESIS_REVIEW_FOR_LUCA.md
+*.patch

--- a/contracts/v1/draft/BURN_DESIGN.md
+++ b/contracts/v1/draft/BURN_DESIGN.md
@@ -1,0 +1,110 @@
+# DRAFT — Burn ErgoName (registry delete) branch
+
+**Status:** proposal for the genesis bundle. Not deployed; not on the current chain.
+**For review by:** Luca (registry author).
+**Goal:** let a name's owner permanently delete it — remove its entry from the
+registry AVL tree **and** burn the name NFT, freeing the name to be registered again.
+
+The current `registry.es` has only a mint (insert) branch + the multisig escape
+hatch — no removal path. This adds an owner-authorised **Burn ErgoName** branch,
+mirroring the proven subname **self-burn (action 2)** in `subname_registry.es`.
+
+Files:
+- `ergonames_v1_registry_burn_branch.es` — faithful, compilable repro of the branch.
+- `burn_satisfiability_test.mjs` — proves it compiles + is type-consistent (no H4-class dead-branch).
+
+---
+
+## Transaction shape
+
+```
+Burn ErgoName
+  Inputs:   INPUTS(0) = Registry (SELF)
+            INPUTS(1) = ErgoName NFT box (owner-signed P2PK)
+  Outputs:  OUTPUTS(0) = Registry'  (recreated, name removed from the AVL)
+            OUTPUTS(1) = owner refund (NFT box value − fee, owner's concern)
+            OUTPUTS(2) = miner fee
+            → the ErgoName token appears in NO output (burned)
+  Context:  getVar(0)=ErgoNameHash, getVar(1)=LookUpProof,
+            getVar(2)=RemoveProof,  getVar(3)=burn action byte (== 1)
+```
+
+## What the branch enforces (see the `.es`)
+- **`validErgoName`** — `previousRegistry.get(ergoNameHash, lookupProof)` equals the
+  token id held in `INPUTS(1)`. Binds the removed name to the burned token, so you
+  can't remove name B while burning token A.
+- **`validRemoval`** — `previousRegistry.remove(ergoNameHash, removeProof)` digest ==
+  `OUTPUTS(0).R4` digest. The AVL entry is gone.
+- **`validBurn`** — the token id is absent from every output. Destroyed, not moved.
+- **`validSelfRecreation`** — registry recreated unchanged except its (smaller) tree;
+  the cumulative state counter (R5), age threshold (R6), and price map (R7) are preserved.
+
+**Authorisation is implicit and sufficient:** spending `INPUTS(1)` requires the
+owner's signature, so only the holder can burn. No `&& userPK` is needed in the
+script (same model as the subname self-burn).
+
+## Two integration points in `registry.es`
+
+**(a)** Alongside `isMintShaped`, add a burn gate. The `if/else` extraction is
+deliberate — `allOf` does NOT short-circuit, so a bare `getVar[Byte](3).get` would
+throw on non-burn txs and break the escape hatch (an H4-class trap):
+
+```scala
+val burnAction: Int = if (getVar[Byte](3).isDefined) getVar[Byte](3).get.toInt else -1
+val burnRequested: Boolean = allOf(Coll(
+    !isMintShaped,
+    (burnAction == 1),
+    getVar[Coll[Byte]](0).isDefined,   // ErgoNameHash
+    getVar[Coll[Byte]](1).isDefined,   // LookUpProof
+    getVar[Coll[Byte]](2).isDefined    // RemoveProof
+))
+```
+
+**(b)** Insert a branch between the mint `if` and the final `else`:
+
+```scala
+if (isMintShaped) {
+    ... existing mint ...
+    sigmaProp(validMintErgoNameTx) || $ergonameMultiSigSigmaProp   // (H3 fix removes the || here, separately)
+} else if (burnRequested) {
+    ... validBurnErgoNameTx (see the .es) ...
+    sigmaProp(validBurnErgoNameTx)        // H3-correct: NO || multisig
+} else {
+    $ergonameMultiSigSigmaProp            // migration escape hatch, unchanged
+}
+```
+
+Gating rationale: a mint is `isMintShaped` (≠ burn); a migration sets no burn vars
+(falls to `else`); only a deliberately burn-shaped tx hits the branch, and it has
+**no `|| multisig`** so a governance key can't satisfy it without `validBurn` (the
+H3 lesson). A malformed burn simply fails — the operator never sets the burn vars
+for a migration, so the multisig path stays reachable for everything else.
+
+## Genesis prerequisite — AVL config (interacts with H2)
+The registry AVL tree must be created at genesis with **`removeAllowed = true`**
+(today it is insert-only). H2's fix pins the *full* tree config (flags + keyLength)
+on every recreation — so the burn branch and H2 must be designed together: the
+pinned config now includes `insertAllowed = true, removeAllowed = true`.
+
+## Off-chain follow-ups (after the branch is approved)
+1. **Bot** — generate the `lookupProof` (tokenId for the name) + `removeProof`
+   (AVL delete) for the burn tx, exactly as it generates the insert proof at
+   register. New endpoint, e.g. `POST /burn-prepare {name, userAddress}`.
+2. **Frontend** — a "Burn / delete this name" control on the name's Records card,
+   behind a hard, explicit confirmation: **irreversible, and the name becomes free
+   for anyone to register again.**
+3. **Indexer** — on detecting the burn (registry tx that removes the key), drop the
+   `registrations` row so resolution returns "available" cleanly (not a tombstone).
+
+## Notes / risks
+- **Irreversible + releases the name.** A burned name is immediately re-registrable
+  by anyone. That's the owner's deliberate choice; the UI must say so unmistakably.
+- Compatible with "lifetime ownership" — the owner is *voluntarily* ending ownership.
+- **Surface:** this adds one branch to the most security-critical contract right as
+  we're keeping the launch set lean. It's far simpler than subnames (self-contained,
+  owner-authorised, fails closed, proven template), so the added risk is modest — but
+  it's a launch-scope call: include at genesis, or hold for the first post-launch genesis.
+- **Testing:** the satisfiability test guards the dead-branch trap. A full sigmastate
+  property test — construct a real burn tx with a populated AVL tree + valid
+  remove/lookup proofs and assert it validates (and that a wrong-token / wrong-owner
+  burn fails) — belongs in the genesis property-test pass.

--- a/contracts/v1/draft/burn_satisfiability_test.mjs
+++ b/contracts/v1/draft/burn_satisfiability_test.mjs
@@ -1,0 +1,64 @@
+// Satisfiability test for the proposed "Burn ErgoName" registry branch.
+//
+// The complement of the auditor's H4 reduction test: instead of proving a branch
+// is UNSATISFIABLE, this proves the burn branch is SOUND and REACHABLE —
+//   1. it compiles to a valid ErgoTree (deployable), and
+//   2. no register is read at two incompatible types (the H4 failure mode),
+// so it can't be dead-on-arrival the way the subname mint branch was.
+//
+// Full proof (construct a real burn tx + AVL remove proof and run it through the
+// sigmastate interpreter) belongs in the genesis property-test pass; this guards
+// the structural trap that static review keeps missing.
+import { readFileSync } from "node:fs";
+import { compile } from "@fleet-sdk/compiler";
+
+const line = "=".repeat(70);
+console.log(line);
+console.log("ErgoNames registry — Burn ErgoName branch satisfiability test");
+console.log(line);
+
+const src = readFileSync(new URL("./ergonames_v1_registry_burn_branch.es", import.meta.url), "utf8");
+
+// ---- 1. Compiles to a valid ErgoTree? ----
+let compiled = false, info = "";
+try {
+  const tree = compile(src, { version: 1 });
+  info = tree.toHex();
+  compiled = true;
+} catch (e) {
+  info = "COMPILE ERROR: " + e.message;
+}
+console.log("\n[1] Compiles to a valid ErgoTree (deployable):", compiled ? "YES" : "NO");
+console.log("    " + (compiled ? info.slice(0, 48) + "… (" + info.length / 2 + " bytes)" : info));
+
+// ---- 2. Register-type consistency (the H4 guard) ----
+// Every typed register read in the branch; each register must demand exactly ONE
+// type, or some read necessarily yields None and .get reverts (H4-class).
+// `.+?` (not `[^\]]`) so bracketed types like Coll[BigInt] / (Coll[Byte], Long)
+// are captured whole — the `].get` anchor stops at the register's closing bracket.
+const reads = [...src.matchAll(/\.(R[4-9])\[(.+?)\]\.get/g)].map((m) => ({
+  reg: m[1],
+  type: m[2].replace(/\s+/g, " ").trim(),
+}));
+const byReg = {};
+for (const r of reads) (byReg[r.reg] ??= new Set()).add(r.type);
+
+console.log("\n[2] Register reads in the branch (each must be a single type):");
+let conflict = false;
+for (const [reg, types] of Object.entries(byReg).sort()) {
+  const ok = types.size === 1;
+  conflict ||= !ok;
+  console.log(`    ${reg}: ${[...types].join("  |  ")}   ${ok ? "✓" : "✗ TWO TYPES — H4-class conflict"}`);
+}
+
+// ---- Verdict ----
+console.log("\n" + line);
+const pass = compiled && !conflict;
+console.log(
+  "VERDICT:",
+  pass
+    ? "burn branch COMPILES and is type-consistent → satisfiable (not dead code)."
+    : "PROBLEM — " + (!compiled ? "does not compile." : "a register is read at two types (H4-class).")
+);
+console.log(line);
+process.exit(pass ? 0 : 1);

--- a/contracts/v1/draft/ergonames_v1_registry_burn_branch.es
+++ b/contracts/v1/draft/ergonames_v1_registry_burn_branch.es
@@ -1,0 +1,76 @@
+{
+    // ===== DRAFT: Burn ErgoName branch for ergonames_v1_registry.es =====
+    // Faithful, compilable reproduction of the proposed "Burn ErgoName" branch
+    // (the exact reads/AVL ops it adds to the registry). Mirrors the subname
+    // registry's self-burn (action 2). See BURN_DESIGN.md for integration.
+    //
+    // Burn ErgoName Tx
+    //   Inputs:  Registry (SELF, INPUTS(0)), ErgoNameNFT (INPUTS(1), owner-signed)
+    //   Outputs: Registry' (OUTPUTS(0)); owner refund + miner fee follow.
+    //            The ErgoName token appears in NO output (burned).
+    //   Context: getVar(0)=ErgoNameHash, getVar(1)=LookUpProof,
+    //            getVar(2)=RemoveProof, getVar(3)=burn action byte (==1)
+
+    // ---- SELF (registry) registers — identical types to the mint branch ----
+    val previousRegistry: AvlTree           = SELF.R4[AvlTree].get
+    val previousState: (Coll[Byte], Long)   = SELF.R5[(Coll[Byte], Long)].get
+    val ageThreshold: (Int, Int)            = SELF.R6[(Int, Int)].get
+    val priceMap: Coll[BigInt]              = SELF.R7[Coll[BigInt]].get
+
+    val _ergoNameHash: Coll[Byte]   = getVar[Coll[Byte]](0).get
+    val _lookupProof: Coll[Byte]    = getVar[Coll[Byte]](1).get
+    val _removeProof: Coll[Byte]    = getVar[Coll[Byte]](2).get
+
+    val ergoNameNftBoxIn: Box       = INPUTS(1)
+    val registryBoxOut: Box         = OUTPUTS(0)
+
+    val burnedTokenId: Coll[Byte]   = ergoNameNftBoxIn.tokens(0)._1
+
+    // The registry maps this name to exactly the token being burned. Spending
+    // the NFT box requires the owner's signature, so providing it IS the
+    // authorisation; this binds the removed name to that owned token (you cannot
+    // burn token A while removing name B, nor remove a name you do not hold).
+    val validErgoName: Boolean = {
+        val tokenId: Option[Coll[Byte]] = previousRegistry.get(_ergoNameHash, _lookupProof)
+        if (tokenId.isDefined) {
+            (tokenId.get == burnedTokenId)
+        } else {
+            false
+        }
+    }
+
+    // The name's entry is removed from the registry AVL tree. REQUIRES the tree
+    // to have been created with removeAllowed = true (genesis config — see H2).
+    val validRemoval: Boolean = {
+        val newRegistry: AvlTree = previousRegistry.remove(Coll(_ergoNameHash), _removeProof).get
+        (registryBoxOut.R4[AvlTree].get.digest == newRegistry.digest)
+    }
+
+    // The ErgoName token is destroyed: it appears in no output.
+    val validBurn: Boolean = {
+        OUTPUTS.forall { (o: Box) =>
+            o.tokens.forall { (t: (Coll[Byte], Long)) => (t._1 != burnedTokenId) }
+        }
+    }
+
+    // Registry recreated unchanged except its (now-smaller) AVL tree: the
+    // cumulative state counter, age threshold and price map are preserved.
+    val validSelfRecreation: Boolean = {
+        allOf(Coll(
+            (registryBoxOut.value == SELF.value),
+            (registryBoxOut.propositionBytes == SELF.propositionBytes),
+            (registryBoxOut.tokens(0) == SELF.tokens(0)),
+            (registryBoxOut.R5[(Coll[Byte], Long)].get == previousState),
+            (registryBoxOut.R6[(Int, Int)].get == ageThreshold),
+            (registryBoxOut.R7[Coll[BigInt]].get == priceMap)
+        ))
+    }
+
+    sigmaProp(allOf(Coll(
+        validErgoName,
+        validRemoval,
+        validBurn,
+        validSelfRecreation
+    )))
+
+}

--- a/contracts/v1/draft/genesis_compile_check.mjs
+++ b/contracts/v1/draft/genesis_compile_check.mjs
@@ -1,0 +1,57 @@
+// Genesis compile-check: verify each v1 contract still compiles to a valid
+// ErgoTree after the hardening edits. The real compiler (AppKit ContractCompile)
+// injects the `$`-prefixed compile-time constants; here we substitute
+// type-correct STUBS so Fleet's compiler can type-check the source (the stub
+// values don't affect whether the ErgoScript is well-formed — only types do).
+//
+// Run: node genesis_compile_check.mjs
+import { compile } from "@fleet-sdk/compiler";
+import { readFileSync } from "node:fs";
+
+const H32 = 'fromBase16("0000000000000000000000000000000000000000000000000000000000000000")';
+// Only the INJECTED constants (no inline `val $x =`). $ergonameMultiSigSigmaProp
+// is declared inline in the source, so it is NOT stubbed.
+const STUBS = {
+  $subNameContractBytesHash: H32,
+  $ergoNameFeeContractBytesHash: H32,
+  $revealContractBytesHash: H32,
+  $commitContractBytesHash: H32,
+  $configSingletonTokenId: H32,
+  $sigUsdOracleSingletonTokenId: H32,
+  $ergoNameCollectionSingletonTokenId: H32,
+  $ergoNameCollectionTokenId: H32,
+  $ergonameCollectionSingletonTokenId: H32,
+  $ergonameCollectionTokenId: H32,
+  $revealErgoTreeBytesHash: H32,
+  $revealProxyErgoTreeBytesHash: H32,
+  $registrySingletonTokenId: H32,
+  $maxCommitBoxAge: "30",
+  $recipientPropBytes: `Coll(${H32}, ${H32})`,
+  $recipientShares: "Coll(500L, 500L)",
+};
+
+function stub(src) {
+  let out = src;
+  for (const [name, val] of Object.entries(STUBS)) {
+    // Replace the injected constant ONLY where it is not being declared as an inline val.
+    out = out.replaceAll(name, val);
+  }
+  return out;
+}
+
+const contracts = ["reveal", "fee_split", "registry", "collection", "subname_registry", "commit", "reveal_proxy", "config"];
+let failed = 0;
+for (const f of contracts) {
+  let src;
+  try { src = readFileSync(new URL(`../ergonames_v1_${f}.es`, import.meta.url), "utf8"); }
+  catch { console.log(`${f.padEnd(18)} (no file)`); continue; }
+  try {
+    const tree = compile(stub(src), { version: 1 });
+    console.log(`${f.padEnd(18)} OK  ${tree.toHex().length / 2} bytes`);
+  } catch (e) {
+    console.log(`${f.padEnd(18)} FAIL ${String(e.message).split("\n")[0].slice(0, 100)}`);
+    failed++;
+  }
+}
+console.log(failed ? `\n${failed} contract(s) failed to compile` : "\nall contracts compile ✓");
+process.exit(failed ? 1 : 0);

--- a/contracts/v1/draft/genesis_property_check.mjs
+++ b/contracts/v1/draft/genesis_property_check.mjs
@@ -1,0 +1,62 @@
+// Genesis property/satisfiability check (static tier).
+//
+// Two guards, per contract, that DON'T need the AVL prover or the live
+// interpreter (those authoritative tests need the Scala/AppKit toolchain — see
+// GENESIS_PROPERTY_TESTS.md):
+//   [1] compiles to a valid ErgoTree (stubs the injected $ constants), and
+//   [2] register-type consistency — no box register is read at two incompatible
+//       types in the source, the exact H4 dead-branch trap (a register holds one
+//       typed constant, so a second-typed .get necessarily reverts).
+//
+// The active launch contracts must be clean. subname_registry is EXPECTED to
+// flag (its mint branch is the known-dead H4 code, shipped DISABLED at genesis).
+import { readFileSync } from "node:fs";
+import { compile } from "@fleet-sdk/compiler";
+
+const H32 = 'fromBase16("0000000000000000000000000000000000000000000000000000000000000000")';
+const STUBS = {
+  $revealContractBytesHash: H32, $subNameContractBytesHash: H32, $ergoNameFeeContractBytesHash: H32,
+  $commitContractBytesHash: H32, $configSingletonTokenId: H32, $sigUsdOracleSingletonTokenId: H32,
+  $ergoNameCollectionSingletonTokenId: H32, $ergoNameCollectionTokenId: H32,
+  $ergonameCollectionSingletonTokenId: H32, $ergonameCollectionTokenId: H32,
+  $revealErgoTreeBytesHash: H32, $revealProxyErgoTreeBytesHash: H32, $registrySingletonTokenId: H32,
+  $maxCommitBoxAge: "30", $recipientPropBytes: `Coll(${H32}, ${H32})`, $recipientShares: "Coll(500L, 500L)",
+};
+const stub = (s) => Object.entries(STUBS).reduce((o, [k, v]) => o.replaceAll(k, v), s);
+
+// Active launch set must be fully clean; subname_registry ships disabled (dead
+// H4 mint branch retained, multisig-migratable) so its conflict is expected.
+const ACTIVE = ["reveal", "fee_split", "registry", "collection", "commit", "reveal_proxy", "config"];
+const DISABLED = ["subname_registry"];
+
+let hardFail = 0;
+for (const f of [...ACTIVE, ...DISABLED]) {
+  const src = readFileSync(new URL(`../ergonames_v1_${f}.es`, import.meta.url), "utf8");
+  const disabled = DISABLED.includes(f);
+
+  // [1] compile
+  let compiled = true, bytes = 0;
+  try { bytes = compile(stub(src), { version: 1 }).toHex().length / 2; }
+  catch (e) { compiled = false; }
+
+  // [2] register-type consistency (H4 guard). Group by RECEIVER + register
+  // (SELF.R4, sigUsdOracleBoxIn.R4, …) so reading the SAME box's register at two
+  // types (the H4 trap) is flagged, WITHOUT false-positiving legit multi-box
+  // reads (oracle R4=Long vs registry R4=AvlTree are different boxes).
+  const byReg = {};
+  for (const m of src.matchAll(/([A-Za-z_]\w*(?:\(\d+\))?)\.(R[4-9])\[(.+?)\]\.get/g)) {
+    const key = `${m[1]}.${m[2]}`;
+    const type = m[3].replace(/\s+/g, " ").trim();
+    (byReg[key] ??= new Set()).add(type);
+  }
+  const conflicts = Object.entries(byReg).filter(([, t]) => t.size > 1);
+
+  const ok = compiled && conflicts.length === 0;
+  const tag = disabled ? (ok ? "OK (disabled)" : "EXPECTED-CONFLICT (disabled)") : (ok ? "OK" : "FAIL");
+  console.log(`${f.padEnd(18)} compile:${compiled ? "✓" : "✗"} types:${conflicts.length === 0 ? "✓" : "✗"}  ${bytes ? bytes + "b" : ""}  ${tag}`);
+  for (const [key, types] of conflicts) console.log(`    ${key} read at: ${[...types].join("  |  ")}`);
+  if (!disabled && !ok) hardFail++;
+}
+
+console.log(hardFail ? `\n${hardFail} ACTIVE contract(s) failed` : "\nactive launch set: compiles + H4-type-consistent ✓");
+process.exit(hardFail ? 1 : 0);

--- a/contracts/v1/draft/package-lock.json
+++ b/contracts/v1/draft/package-lock.json
@@ -1,0 +1,133 @@
+{
+  "name": "ergonames-registry-burn-draft",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ergonames-registry-burn-draft",
+      "dependencies": {
+        "@fleet-sdk/compiler": "0.12.0"
+      }
+    },
+    "node_modules/@fleet-sdk/common": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@fleet-sdk/common/-/common-0.10.0.tgz",
+      "integrity": "sha512-N92zENyHYhKtKxhJ6jJbWgV3PCkCGM0LYLmn6OOXNqDVbwT9UFgHOTt7eXFd9tqIhwMMPCnlffNe4c+P+CnsJA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@fleet-sdk/compiler": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@fleet-sdk/compiler/-/compiler-0.12.0.tgz",
+      "integrity": "sha512-WH05qMRmWe8qTI1oX2NZ3qJobp2ZYPh3DqAAtKRPxmeHmfWmvFWM6QHwWeGR7M86QCQczWNdqeOY7qJKs12G4g==",
+      "dependencies": {
+        "@fleet-sdk/common": "^0.10.0",
+        "@fleet-sdk/core": "^0.12.0",
+        "@fleet-sdk/crypto": "^0.11.0",
+        "@fleet-sdk/serializer": "^0.11.0",
+        "sigmastate-js": "0.4.6"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@fleet-sdk/core": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@fleet-sdk/core/-/core-0.12.0.tgz",
+      "integrity": "sha512-AYdfivEzfokem2eovnhp5rfv+cFrVR87l/ff71uxt1Xn1Arv0QivNtXn9H00i0t3LkiTxI7ttgU56FAbjWbUKw==",
+      "dependencies": {
+        "@fleet-sdk/common": "^0.10.0",
+        "@fleet-sdk/crypto": "^0.11.0",
+        "@fleet-sdk/serializer": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@fleet-sdk/crypto": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@fleet-sdk/crypto/-/crypto-0.11.0.tgz",
+      "integrity": "sha512-oGyrnL0AyzPSsPdA32y4TEFQ6vJlNDMt9nwiArd2TYbtRCDMNTslHQmC/An4clf4R0e/c4yuZJSdfzHC3F0ssQ==",
+      "dependencies": {
+        "@fleet-sdk/common": "^0.10.0",
+        "@noble/hashes": "^1.8.0",
+        "@scure/base": "^1.2.6"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@fleet-sdk/serializer": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@fleet-sdk/serializer/-/serializer-0.11.0.tgz",
+      "integrity": "sha512-EYun0nzxJn+23aOeaMM5COj62ibVrzgNOx2I6AM6P23mRs72I0Dv2prdBnU/lst4hqbNHi8a1E6UNvpjH2vhGQ==",
+      "dependencies": {
+        "@fleet-sdk/common": "^0.10.0",
+        "@fleet-sdk/crypto": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/sigmajs-crypto-facade": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/sigmajs-crypto-facade/-/sigmajs-crypto-facade-0.0.7.tgz",
+      "integrity": "sha512-4XK8ZS9NKAbo8aGnU6o5GkBW6Upl8+OK8A1KreVDMAamfvZ0iq4LoVH8rHaeEPf9moVtaC4QZY5RYI+0OwiydA==",
+      "dependencies": {
+        "@noble/hashes": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sigmastate-js": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/sigmastate-js/-/sigmastate-js-0.4.6.tgz",
+      "integrity": "sha512-Vo/TSFbkKrG28eiWn7EmoaBNgyabC6En6B7cKjb3z2ivBpFBMCGxUZgmKu83GgJboRvCikZ3/vvWFfbxpbloig==",
+      "dependencies": {
+        "@fleet-sdk/common": "0.1.3",
+        "@noble/hashes": "1.1.4",
+        "sigmajs-crypto-facade": "0.0.7"
+      }
+    },
+    "node_modules/sigmastate-js/node_modules/@fleet-sdk/common": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@fleet-sdk/common/-/common-0.1.3.tgz",
+      "integrity": "sha512-gYEkHhgGpgIcmCL3nCw8E9zHkT2WLmR+mPdxFlUE6fwcwISURbJrP6W9mF7D5Y0ShAP5Is2w3edh7AyIc7ctIQ==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/sigmastate-js/node_modules/@noble/hashes": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.4.tgz",
+      "integrity": "sha512-+PYsVPrTSqtVjatKt2A/Proukn2Yrz61OBThOCKErc5w2/r1Fh37vbDv0Eah7pyNltrmacjwTvdw3JoR+WE4TA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    }
+  }
+}

--- a/contracts/v1/draft/package.json
+++ b/contracts/v1/draft/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "ergonames-registry-burn-draft",
+  "private": true,
+  "type": "module",
+  "scripts": { "test": "node burn_satisfiability_test.mjs" },
+  "dependencies": {
+    "@fleet-sdk/compiler": "0.12.0"
+  }
+}

--- a/contracts/v1/ergonames_v1_collection.es
+++ b/contracts/v1/ergonames_v1_collection.es
@@ -42,9 +42,13 @@
     val ergonameCollectionTokenAmount = SELF.tokens.fold(0L, { (sum: Long, t: (Coll[Byte], Long)) =>
         if (t._1 == $ergonameCollectionTokenId) sum + t._2 else sum
     })
-    val address1 = PK("9h2g3WsPy5Ty2Ekq4w9tKMVrco4d5iu9dAxYLoTFoDggwSCW5yk")
-    val address2 = PK("9fXDsjy38dyu1bzRbe6tp6Ltw4m2u6je98ujv82pbGw78uExcd9")
-    val $ergonameMultiSigSigmaProp = atLeast(1, Coll(address1, address2))
+    // Genesis 2-of-4 governance multisig (Minotaur, validated 2026-06-29).
+    // Replaces the operator-derived 1-of-2 placeholder (H3 key replacement).
+    val govA = PK("9g5yzitxX53B4RVi1DHLjrMx7iwTQn38kLG2XVVkhvHvcB1TcEz")
+    val govB = PK("9gCJDv78SUUes6sNo81KqbP4yu3vHU6GtcatvmySiBsRoU1k4T8")
+    val govC = PK("9hdYFtdV8JLXJho4wAzy6dB6DHQn4gvZsmf4vf1kbkggJ59Wn3Z")
+    val govD = PK("9iJV2D1gzvWeBbSXHPgTai3S41CjoBBodxMB9DB2Dwt1kaRA9z2")
+    val $ergonameMultiSigSigmaProp = atLeast(2, Coll(govA, govB, govC, govD))
 
     // Shape guards: reveal txs have 4 outputs, refunds 3; anything else falls
     // through to the multisig escape hatch (migrations use 2 outputs) instead

--- a/contracts/v1/ergonames_v1_fee_split.es
+++ b/contracts/v1/ergonames_v1_fee_split.es
@@ -23,9 +23,13 @@
     // $recipientPropBytes: Coll[Coll[Byte]] - propositionBytes per recipient
     // $recipientShares: Coll[Long]          - per-mille share per recipient
 
-    val address1 = PK("9h2g3WsPy5Ty2Ekq4w9tKMVrco4d5iu9dAxYLoTFoDggwSCW5yk")
-    val address2 = PK("9fXDsjy38dyu1bzRbe6tp6Ltw4m2u6je98ujv82pbGw78uExcd9")
-    val $ergonameMultiSigSigmaProp = atLeast(1, Coll(address1, address2))
+    // Genesis 2-of-4 governance multisig (Minotaur, validated 2026-06-29).
+    // Replaces the operator-derived 1-of-2 placeholder (H3 key replacement).
+    val govA = PK("9g5yzitxX53B4RVi1DHLjrMx7iwTQn38kLG2XVVkhvHvcB1TcEz")
+    val govB = PK("9gCJDv78SUUes6sNo81KqbP4yu3vHU6GtcatvmySiBsRoU1k4T8")
+    val govC = PK("9hdYFtdV8JLXJho4wAzy6dB6DHQn4gvZsmf4vf1kbkggJ59Wn3Z")
+    val govD = PK("9iJV2D1gzvWeBbSXHPgTai3S41CjoBBodxMB9DB2Dwt1kaRA9z2")
+    val $ergonameMultiSigSigmaProp = atLeast(2, Coll(govA, govB, govC, govD))
 
     val recipientCount: Int = $recipientPropBytes.size
 
@@ -59,7 +63,9 @@
 
         }
 
-        sigmaProp(validDistribution) || $ergonameMultiSigSigmaProp
+        // H3: multisig only in the `else` branch; a distribution-shaped tx must
+        // satisfy validDistribution (no multisig override).
+        sigmaProp(validDistribution)
 
     } else {
 

--- a/contracts/v1/ergonames_v1_registry.es
+++ b/contracts/v1/ergonames_v1_registry.es
@@ -105,6 +105,20 @@
         getVar[Coll[Byte]](1).isDefined
     ))
 
+    // Burn ErgoName gate. `allOf` does NOT short-circuit, so reading getVar(3).get
+    // unconditionally would throw on non-burn spends and brick the escape hatch
+    // (an H4-class trap); extract the action defensively. Only a deliberately
+    // burn-shaped tx (not mint-shaped, burn action byte == 1, the 3 proofs set)
+    // enters the burn branch below.
+    val burnAction: Int = if (getVar[Byte](3).isDefined) getVar[Byte](3).get.toInt else -1
+    val burnRequested: Boolean = allOf(Coll(
+        !isMintShaped,
+        (burnAction == 1),
+        getVar[Coll[Byte]](0).isDefined,   // ErgoNameHash
+        getVar[Coll[Byte]](1).isDefined,   // LookUpProof
+        getVar[Coll[Byte]](2).isDefined    // RemoveProof
+    ))
+
     if (isMintShaped) {
 
     val _ergoNameHash: Coll[Byte]   = getVar[Coll[Byte]](0).get
@@ -310,6 +324,72 @@
     // below. A mint-shaped tx must satisfy validMint — the multisig can no
     // longer override mint validation to seize the user's boxes.
     sigmaProp(validMintErgoNameTx)
+
+    } else if (burnRequested) {
+
+        // ===== Burn ErgoName Tx (the owner permanently deletes their name) =====
+        // Owner-authorised implicitly: spending INPUTS(1) (the ErgoName NFT box)
+        // requires the owner's signature — so providing it IS the authorisation.
+        // Mirrors the subname self-burn. The name becomes re-registrable.
+        val validBurnErgoNameTx: Boolean = {
+
+            val _burnErgoNameHash: Coll[Byte] = getVar[Coll[Byte]](0).get
+            val _burnLookupProof: Coll[Byte]  = getVar[Coll[Byte]](1).get
+            val _burnRemoveProof: Coll[Byte]  = getVar[Coll[Byte]](2).get
+
+            val ergoNameNftBoxIn: Box   = INPUTS(1)
+            val burnRegistryBoxOut: Box = OUTPUTS(0)
+            val burnedTokenId: Coll[Byte] = ergoNameNftBoxIn.tokens(0)._1
+
+            // Bind the removed name to the owned token: the registry must map this
+            // name to exactly the token being burned (can't remove name B while
+            // burning token A, nor remove a name you don't hold).
+            val validErgoName: Boolean = {
+                val tokenId: Option[Coll[Byte]] = previousRegistry.get(_burnErgoNameHash, _burnLookupProof)
+                if (tokenId.isDefined) { (tokenId.get == burnedTokenId) } else { false }
+            }
+
+            // Remove the name from the AVL tree. REQUIRES the genesis tree created
+            // with removeAllowed = true (see H2). Full-config `==` (not just
+            // .digest) pins the flags so the recreated tree keeps insert + remove
+            // enabled — same H2 hardening as the mint path.
+            val validRemoval: Boolean = {
+                val newRegistry: AvlTree = previousRegistry.remove(Coll(_burnErgoNameHash), _burnRemoveProof).get
+                (burnRegistryBoxOut.R4[AvlTree].get == newRegistry)
+            }
+
+            // The ErgoName token is destroyed: it appears in NO output.
+            val validBurn: Boolean = {
+                OUTPUTS.forall { (o: Box) =>
+                    o.tokens.forall { (t: (Coll[Byte], Long)) => (t._1 != burnedTokenId) }
+                }
+            }
+
+            // Registry recreated unchanged except its (now-smaller) tree — the
+            // cumulative state counter, age threshold and price map are preserved.
+            val validSelfRecreation: Boolean = {
+                allOf(Coll(
+                    (burnRegistryBoxOut.value == SELF.value),
+                    (burnRegistryBoxOut.propositionBytes == SELF.propositionBytes),
+                    (burnRegistryBoxOut.tokens(0) == SELF.tokens(0)),
+                    (burnRegistryBoxOut.R5[(Coll[Byte], Long)].get == previousState),
+                    (burnRegistryBoxOut.R6[(Int, Int)].get == ageThreshold),
+                    (burnRegistryBoxOut.R7[Coll[BigInt]].get == priceMap)
+                ))
+            }
+
+            allOf(Coll(
+                validErgoName,
+                validRemoval,
+                validBurn,
+                validSelfRecreation
+            ))
+
+        }
+
+        // H3-correct: NO || multisig. A malformed burn simply fails; migrations
+        // set no burn vars and fall through to the multisig `else` below.
+        sigmaProp(validBurnErgoNameTx)
 
     } else {
 

--- a/contracts/v1/ergonames_v1_registry.es
+++ b/contracts/v1/ergonames_v1_registry.es
@@ -83,9 +83,13 @@
     val minCommitBoxAge: Int                = ageThreshold._1
     val maxCommitBoxAge: Int                = ageThreshold._2
 
-    val address1 = PK("9h2g3WsPy5Ty2Ekq4w9tKMVrco4d5iu9dAxYLoTFoDggwSCW5yk")
-    val address2 = PK("9fXDsjy38dyu1bzRbe6tp6Ltw4m2u6je98ujv82pbGw78uExcd9")
-    val $ergonameMultiSigSigmaProp = atLeast(1, Coll(address1, address2))
+    // Genesis 2-of-4 governance multisig (Minotaur, validated 2026-06-29).
+    // Replaces the operator-derived 1-of-2 placeholder (H3 key replacement).
+    val govA = PK("9g5yzitxX53B4RVi1DHLjrMx7iwTQn38kLG2XVVkhvHvcB1TcEz")
+    val govB = PK("9gCJDv78SUUes6sNo81KqbP4yu3vHU6GtcatvmySiBsRoU1k4T8")
+    val govC = PK("9hdYFtdV8JLXJho4wAzy6dB6DHQn4gvZsmf4vf1kbkggJ59Wn3Z")
+    val govD = PK("9iJV2D1gzvWeBbSXHPgTai3S41CjoBBodxMB9DB2Dwt1kaRA9z2")
+    val $ergonameMultiSigSigmaProp = atLeast(2, Coll(govA, govB, govC, govD))
 
     // The mint validation dereferences inputs, outputs, and context variables
     // that only exist in a well-formed mint tx; evaluating it in any other tx
@@ -310,7 +314,10 @@
 
     }
 
-    sigmaProp(validMintErgoNameTx) || $ergonameMultiSigSigmaProp
+    // H3: the multisig escape hatch lives ONLY in the non-mint `else` branch
+    // below. A mint-shaped tx must satisfy validMint — the multisig can no
+    // longer override mint validation to seize the user's boxes.
+    sigmaProp(validMintErgoNameTx)
 
     } else {
 

--- a/contracts/v1/ergonames_v1_registry.es
+++ b/contracts/v1/ergonames_v1_registry.es
@@ -307,6 +307,16 @@
         // bypassing reveal.es (no collection token burned) yet still inserting a
         // name into the authoritative AVL tree. reveal.es itself authenticates the
         // commit box, so this single binding secures the whole mint input chain.
+        //
+        // REVIEW NOTE (Luca — pick one): this hash check couples registry
+        // compilation to the reveal contract (registry must be compiled AFTER
+        // reveal, and $revealContractBytesHash injected). A self-contained
+        // alternative with no compile-order coupling is:
+        //     revealBoxIn.tokens(0) == ($ergoNameCollectionTokenId, 1L)
+        // The collection token is minted once at genesis and can only ever sit in
+        // the collection box or a reveal box — collection.es only ever sends it to
+        // a reveal box, and reveal.es burns it at mint / returns it at refund — so
+        // it can never reach an attacker's P2PK box. Sound but more indirect.
         val validRevealBoxAuth: Boolean = (blake2b256(revealBoxIn.propositionBytes) == $revealContractBytesHash)
 
         allOf(Coll(

--- a/contracts/v1/ergonames_v1_registry.es
+++ b/contracts/v1/ergonames_v1_registry.es
@@ -22,6 +22,7 @@
     // Context Variables: ErgoNameHash, InsertionProof, LookUpProof
 
     // ===== Compile Time Constants ($) ===== //
+    // $revealContractBytesHash: Coll[Byte]
     // $subNameContractBytesHash: Coll[Byte]
     // $ergoNameFeeContractBytesHash: Coll[Byte]
     // $configSingletonTokenId: Coll[Byte]
@@ -185,7 +186,13 @@
                val newRegistry: AvlTree = previousRegistry.insert(Coll((_ergoNameHash, ergoNameTokenId)), _insertionProof).get
 
                 allOf(Coll(
-                    (registryBoxOut.R4[AvlTree].get.digest == newRegistry.digest),
+                    // H2: pin the FULL tree config (digest + insert flag + keyLength),
+                    // not just the digest — else a mint-tx builder can recreate R4 with
+                    // the same digest but insert DISABLED, permanently bricking every
+                    // future mint (previousRegistry.insert returns None → .get throws).
+                    // AvlTree `==` compares all fields; newRegistry carries previous-
+                    // Registry's flags/keyLength, so this also keeps insert enabled.
+                    (registryBoxOut.R4[AvlTree].get == newRegistry),
                     (_ergoNameHash == blake2b256(ergoNameBytes))
                 ))
 
@@ -268,43 +275,28 @@
 
             } else {
 
-                val ergoDexErg2TokenPoolBoxIn: Box              = CONTEXT.dataInputs(1)
-                val configBoxIn: Box                            = CONTEXT.dataInputs(2)
-
-                val paymentTokenId: Coll[Byte]                  = revealBoxIn.tokens(0)._1
-                val configAvlTree: AvlTree                      = configBoxIn.R4[AvlTree].get
-                val _lookupProof: Coll[Byte]                    = getVar[Coll[Byte]](2).get
-                val configElement: Coll[Byte]                   = configAvlTree.get(paymentTokenId, _lookupProof)
-
-                if (configElement.isEmpty) {
-                    false
-                } else {
-
-                    val ergoDexErg2TokenPoolId: Coll[Byte]      = configElement.get.slice(0, 32)
-                    val nanoErgVolume_2: BigInt                 = ergoDexErg2TokenPoolBoxIn.value
-                    val tokenVolume_2: BigInt                   = ergoDexErg2TokenPoolBoxIn.tokens(2)._2
-                    val equivalentPaymentTokenAmount: BigInt    = (tokenVolume_2 * equivalentNanoErg) / nanoErgVolume_2
-
-                    val validConfigBoxIn: Boolean               = (configBoxIn.tokens(0)._1 == $configSingletonTokenId)
-                    val validErgoDexErg2TokenPool: Boolean      = (ergoDexErg2TokenPoolBoxIn.tokens(0)._1 == ergoDexErg2TokenPoolId)
-                    val validFeePayment: Boolean                = ((ergoNameFeeBoxOut.tokens(0)._1 == paymentTokenId) && (ergoNameFeeBoxOut.tokens(0)._2.toBigInt >= equivalentPaymentTokenAmount))
-                    val validFeeAddress: Boolean                = (blake2b256(ergoNameFeeBoxOut.propositionBytes) == $ergoNameFeeContractBytesHash)
-
-                    allOf(Coll(
-                        validSigUsdOracle,
-                        validConfigBoxIn,
-                        validErgoDexErg2TokenPool,
-                        validFeePayment,
-                        validFeeAddress
-                    ))
-
-                }
+                // M2: token payments are DISABLED at genesis. The token path derived
+                // the price from instantaneous ErgoDex pool reserves with NO slippage
+                // bound or oracle anchoring (the ERG path enforces ±5% via isWithin),
+                // so a pool imbalance could over/underprice a name. Any non-default
+                // payment mode is rejected here; the token-payment path must be
+                // rebuilt (SigUSD-oracle-anchored + a slippage window) and re-audited
+                // before re-enabling. The genesis config tree also stays empty.
+                false
 
             }
 
         }
 
+        // M1: authenticate INPUTS(0) as the real reveal contract. Without this an
+        // attacker can pass their own P2PK box with a crafted R9 as INPUTS(0),
+        // bypassing reveal.es (no collection token burned) yet still inserting a
+        // name into the authoritative AVL tree. reveal.es itself authenticates the
+        // commit box, so this single binding secures the whole mint input chain.
+        val validRevealBoxAuth: Boolean = (blake2b256(revealBoxIn.propositionBytes) == $revealContractBytesHash)
+
         allOf(Coll(
+            validRevealBoxAuth,
             validErgoNameFormat,
             validCommit,
             validRegistryUpdate,

--- a/contracts/v1/ergonames_v1_reveal.es
+++ b/contracts/v1/ergonames_v1_reveal.es
@@ -197,6 +197,27 @@
 
             }
 
+            // H1: cap the minted name-token supply. The minted id == SELF.id (the
+            // reveal box id); Ergo lets a tx mint an arbitrary TOTAL of that id, so
+            // an unconstrained output (e.g. the tx-operator fee box) could otherwise
+            // carry (SELF.id, 1_000_000). Pin the id to appear ONLY at
+            // OUTPUTS(0).tokens(0) (the ErgoName NFT) and OUTPUTS(2).tokens(0) (the
+            // subname-registry identifier), each exactly (SELF.id, 1L) — so the total
+            // minted supply is exactly 2 and no extra output/slot can duplicate it.
+            val validNameTokenSupply: Boolean = {
+                val minted: Coll[Byte] = SELF.id
+                val sanctionedOnly: Boolean = OUTPUTS.indices.forall { (i: Int) =>
+                    OUTPUTS(i).tokens.indices.forall { (j: Int) =>
+                        (OUTPUTS(i).tokens(j)._1 != minted) || ((i == 0 || i == 2) && (j == 0))
+                    }
+                }
+                allOf(Coll(
+                    (OUTPUTS(0).tokens(0) == (minted, 1L)),
+                    (OUTPUTS(2).tokens(0) == (minted, 1L)),
+                    sanctionedOnly
+                ))
+            }
+
             allOf(Coll(
                 validRevealBoxInValue,
                 validCommitBoxIn,
@@ -204,6 +225,7 @@
                 validErgonameIssuanceAmount,
                 validErgoNameMint,
                 validCollectionTokenBurn,
+                validNameTokenSupply,
                 validMinerFeeBoxOut,
                 validTxOperatorFeeBoxOut,
                 (OUTPUTS.size == 6)

--- a/contracts/v1/ergonames_v1_subname_registry.es
+++ b/contracts/v1/ergonames_v1_subname_registry.es
@@ -84,9 +84,16 @@
     }
 
     // ===== Relevant Variables ===== //
-    val address1 = PK("9h2g3WsPy5Ty2Ekq4w9tKMVrco4d5iu9dAxYLoTFoDggwSCW5yk")
-    val address2 = PK("9fXDsjy38dyu1bzRbe6tp6Ltw4m2u6je98ujv82pbGw78uExcd9")
-    val $ergonameMultiSigSigmaProp = atLeast(1, Coll(address1, address2))
+    // Genesis 2-of-4 governance multisig (Minotaur, validated 2026-06-29).
+    // Replaces the operator-derived 1-of-2 placeholder (H3 key replacement).
+    // Subnames ship DISABLED at genesis (mint branch dead per H4); this multisig
+    // guards the per-name subname-registry boxes so the 2-of-4 can migrate them
+    // when the subname feature is rebuilt post-genesis.
+    val govA = PK("9g5yzitxX53B4RVi1DHLjrMx7iwTQn38kLG2XVVkhvHvcB1TcEz")
+    val govB = PK("9gCJDv78SUUes6sNo81KqbP4yu3vHU6GtcatvmySiBsRoU1k4T8")
+    val govC = PK("9hdYFtdV8JLXJho4wAzy6dB6DHQn4gvZsmf4vf1kbkggJ59Wn3Z")
+    val govD = PK("9iJV2D1gzvWeBbSXHPgTai3S41CjoBBodxMB9DB2Dwt1kaRA9z2")
+    val $ergonameMultiSigSigmaProp = atLeast(2, Coll(govA, govB, govC, govD))
 
     // Missing action byte falls through to the multisig escape hatch instead
     // of throwing, which would make the box unspendable for migrations.


### PR DESCRIPTION
Stages the must-fix **contract** security findings (three 2026-06 security reviews + the H4 second audit) for the next genesis recompile + redeploy. Current mainnet is the beta throwaway (test names, no value, purged at genesis); this branch carries every fix genesis must ship.

## Fixes
| # | Sev | Fix | Where |
|---|-----|-----|-------|
| H1 | crit | Cap minted name-token supply — the minted id (`== SELF.id`) may appear only at `OUTPUTS(0/2).tokens(0)`, each `(id,1)` → total exactly 2 | `reveal.es` `validNameTokenSupply` |
| H2 | high | Recreation pins the **full** `AvlTree` (`== newRegistry`: digest+flags+keyLength), not just `.digest` | `registry.es` `validErgoNameInsertion` |
| M1 | high | Authenticate `INPUTS(0)` as the reveal contract (`blake2b256(propBytes) == $revealContractBytesHash`) | `registry.es` `validRevealBoxAuth` |
| H3 | high | Mint/distribution branches are bare `sigmaProp(validX)`; multisig only in `else` | `registry.es`, `fee_split.es` |
| M2 | med | Token-payment mode disabled (priced off AMM spot, no slippage/oracle bound) | `registry.es` |
| Multisig | — | Placeholder `atLeast(1,…)` → the real 2-of-4 `atLeast(2, Coll(4 founders))` | registry / fee_split / collection / subname_registry |
| Burn | — | Owner-authorised delete branch (removes from AVL, burns the NFT) — see `BURN_DESIGN.md` | `registry.es` |
| Subnames | — | Shipped **disabled** (mint branch is the dead H4 code); only the 2-of-4 `else` is live | `subname_registry.es` |

## Verification
- Fleet stub-compile (all 8) + box-scoped H4 type-consistency — `contracts/v1/draft/genesis_property_check.mjs`
- Real AppKit/sigmastate compile of all 8 in DAG order with M1 wired (harness in the deployment repo)
- 4-lens adversarial logic review (correctness / regression / burn / gating) — 0 findings

## For review — 3 calls
1. **M1 form** — hash check (here) vs the self-contained `revealBoxIn.tokens(0) == ($ergoNameCollectionTokenId, 1L)` (no compile-order coupling). Noted in-code at the fix.
2. **Subnames disabled** at genesis (rebuild H4/M3/hash-binding post-genesis) — OK?
3. **Burn** at genesis, or hold for the next one?

## Still for the registry author (AVL-interpreter tier)
The reduction property tests — real mint/burn/migration txs + AVL insert/remove proofs, assert accept/reject through the interpreter — are left for the author (your insert/remove logic + scorex/AppKit toolchain). The real-compile harness is scaffolded (`GenesisPropertyTest.scala`, deployment repo).

## Genesis prerequisites (deploy, post-approval)
Tree `AllOperationsAllowed`; compile order `commit→reveal→subname/fee→registry` (M1 needs the reveal hash) — `ContractCompile.compileRegistryContract` to inject `$revealContractBytesHash`; purge beta test names; redeploy registry; update `manifest_mainnet.json`; bot multisig-funded fee builder + `/burn-prepare`.
